### PR TITLE
enable large file stream message file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 grpclib
 pyee
 requests
-chatie-grpc==0.17.dev4
-wechaty-puppet== 0.0.18
+chatie-grpc>=0.18.12
+wechaty-puppet>=0.2.1

--- a/src/wechaty_puppet_hostie/puppet.py
+++ b/src/wechaty_puppet_hostie/puppet.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import re
+from functools import reduce
 from typing import Optional, List
 from dataclasses import asdict
 import xml.dom.minidom  # type: ignore
@@ -441,8 +442,17 @@ class HostiePuppet(Puppet):
         :param message_id:
         :return:
         """
-        response = await self.puppet_stub.message_file(id=message_id)
-        file_box = FileBox.from_json(response.filebox)
+        file_chunk_data: List[bytes] = []
+        name: str = ""
+
+        async for stream in self.puppet_stub.message_file_stream(id=message_id):
+            file_chunk_data.append(stream.file_box_chunk.data)
+            if not name and stream.file_box_chunk.name:
+                name = stream.file_box_chunk.name
+
+        file_stream = reduce(lambda pre, cu: pre + cu, file_chunk_data)
+        file_box = FileBox.from_stream(file_stream, name=name)
+
         return file_box
 
     async def message_emoticon(self, message: str) -> FileBox:


### PR DESCRIPTION
Fix: https://github.com/wechaty/python-wechaty/issues/160

To enable large file receiving process, stream mode is required.