### PR TITLE
Feature: send file with stream mode

### DIFF
--- a/src/wechaty_puppet_service/file_box_chunk/file_box_chunk_converter.py
+++ b/src/wechaty_puppet_service/file_box_chunk/file_box_chunk_converter.py
@@ -1,0 +1,94 @@
+"""
+Python Wechaty - https://github.com/wechaty/python-wechaty
+
+Authors:    Jingjing WU (吴京京) <https://github.com/wj-Mcat>
+
+2020-now @ Copyright Wechaty
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from __future__ import annotations
+import os
+import math
+from typing import AsyncIterable, List, Optional
+import tempfile
+from uuid import uuid4
+from wechaty_grpc.wechaty.puppet import MessageSendFileStreamRequest
+from wechaty_puppet import FileBox
+from wechaty_grpc.wechaty.puppet import FileBoxChunk
+
+from wechaty_puppet_service.config import CHUNK_SIZE
+
+
+async def pack_file_box_to_chunk(file_box: FileBox) -> AsyncIterable[FileBoxChunk]:
+    """pack file-box instance to async iterator chunks
+
+    Args:
+        file_box (FileBox): the source file-box instance
+
+    Returns:
+        AsyncIterator[FileBoxChunk]: Async Iterator FileBox Chunk
+    """
+    # 1. save file-box as temp file, so that we can read stream from it.
+    temp_dir = tempfile.TemporaryDirectory()
+    file_name = "%s-%s" % (str(uuid4()), file_box.name)
+    file_path = os.path.join(temp_dir.name, file_name)
+    await file_box.to_file(file_path, overwrite=True)
+    
+    # 2. read stream from the temp file
+    streams: bytes = bytes()
+    with open(file_path, 'rb') as f:
+        for line in f:
+            streams += line
+    
+    # 3. split it to chunks
+    size = len(streams)
+    
+    for i in range(math.ceil(size / CHUNK_SIZE)):
+        stream = streams[i * CHUNK_SIZE: (i + 1) * CHUNK_SIZE]
+        yield FileBoxChunk(
+            data=stream,
+            name=file_box.name
+        )
+
+
+async def gen_file_stream_request(
+        conversation_id: str, file_box: FileBox) -> AsyncIterable[MessageSendFileStreamRequest]:
+    chunks = pack_file_box_to_chunk(file_box)
+    async for chunk in chunks:
+        request = MessageSendFileStreamRequest(
+            conversation_id=conversation_id,
+            file_box_chunk=chunk
+        )
+        yield request
+
+
+async def unpack_file_box_chunk(file_box_chunks: List[FileBoxChunk]) -> FileBox:
+    """unpack async iterator filebox chunks to file-box instance
+
+    Args:
+        file_box_chunks (AsyncIterator[FileBox]):
+
+    Returns:
+        FileBox: [description]
+    """
+    # 1. merge chunks
+    buffers: bytes = bytes()
+    name: Optional[str] = None
+    for chunk in file_box_chunks:
+        buffers += chunk.data
+        name = chunk.name
+
+    # 2. gen file-box
+    file_box: FileBox = FileBox.from_buffer(buffers, name)
+    return file_box

--- a/src/wechaty_puppet_service/puppet.py
+++ b/src/wechaty_puppet_service/puppet.py
@@ -85,6 +85,7 @@ from wechaty_puppet_service.utils import (
     extract_host_and_port,
     test_endpoint
 )
+from wechaty_puppet_service.file_box_chunk.file_box_chunk_converter import gen_file_stream_request
 
 log = get_logger('PuppetService')
 
@@ -359,9 +360,10 @@ class PuppetService(Puppet):
         :param file:
         :return:
         """
-        response = await self.puppet_stub.message_send_file(
-            conversation_id=conversation_id,
-            filebox=file.to_json_str()
+
+        request_stream = gen_file_stream_request(conversation_id, file)
+        response = await self.puppet_stub.message_send_file_stream(
+            request_iterator=request_stream
         )
         return response.id
 


### PR DESCRIPTION
Until then, python-wechaty always send file in json-string method which is deprecated. `stream` method is the better way. But I have some problems at implementing method, the main error is from `FileBoxChunk` and `no conversation id`.

## Description

To implement stream request, I think there are two points:

* split file-box into file box chunk with CHUNK_SIZE which is not found in [`file-box-stream`](https://github.com/wechaty/wechaty-puppet-service/tree/main/src/file-box-stream) ❓ ❓
* create async generator containing MessageSendFileStreamRequest to fit stream uploading

You can see the implementation in `file_box_stream` module.

When every time I send file, the service server will throw the error:

```shell
<(<Status.INTERNAL: 13>, 'no conversation id', None)>
```

## Survey

I have read [`file-box-stream`](https://github.com/wechaty/wechaty-puppet-service/tree/main/src/file-box-stream) code which make me confused about the implementation of `file-box-stream`.

So I believe I should only follow the parameters in `message_send_file_stream` method to make it run correctly. 

```python
async def message_send_file_stream(
    self,
    request_iterator: Union[
        AsyncIterable["puppet.MessageSendFileStreamRequest"],
        Iterable["puppet.MessageSendFileStreamRequest"],
    ],
) -> "puppet.MessageSendFileStreamResponse":

    return await self._stream_unary(
        "/wechaty.Puppet/MessageSendFileStream",
        request_iterator,
        puppet.MessageSendFileStreamRequest,
        puppet.MessageSendFileStreamResponse,
    )
```
The above code is the source method in `wechaty-grpc` package.  According to the parameter defination, we should only send async generator of MessageSendFileStreamRequest which can it run correctly, please refer to the files in this pr to get implmentation detail.  

When every time I send the file, the service server will throw the error:

```shell
<(<Status.INTERNAL: 13>, 'no conversation id', None)>
```

But there is actual `conversation_id` field in `MessageSendFileStreamRequest` object. This makes me confused. @huan I can't find the right solution to implement stream way.

## Ideas

* In this implementation, I split json string and filebox data to chunks, it will not work and throw the same error: `no conversation id` from [`unpackConversationIdFileBoxArgsFromPb`](https://github.com/wechaty/wechaty-puppet-service/blob/main/src/file-box-stream/conversation-id-file-box.ts#L25). I think there must be some fields that I have ignored. 
* We used to send json string to server, now we should send json string stream data to server. Is that right ?

@huan  Please help me find the solution of stream way. 